### PR TITLE
Issue 4: Update only up to 5.3.0…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": ">=5.4.0",
-        "guzzlehttp/guzzle": "~5.0.3",
+        "guzzlehttp/guzzle": "~5.3.0",
         "zendframework/zend-stdlib": "~2.3.4"
     },
     "require-dev": {


### PR DESCRIPTION
Because there are dependencies to a newer PHP Version
- Issue https://github.com/detailnet/dfw-notification/issues/4 Upgrade WebhookSender to rely on Guzzle 6
